### PR TITLE
Upgrade request@2.67, no longer depend on insecure qs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt": "~0.4.2"
   },
   "dependencies": {
-    "request": "~2.33.0",
+    "request": "~2.67.0",
     "q": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* Fixes a vulnerability in qs <= 1.0
  * https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking